### PR TITLE
Remove usage of bottle :unneeded

### DIFF
--- a/Formula/jp.rb
+++ b/Formula/jp.rb
@@ -5,8 +5,6 @@ class Jp < Formula
   sha256 "8083f87df1bd550f0cddbb143be82f10e2e6cadaf6b633d133656c593f25e666"
   license "Apache-2.0"
 
-  bottle :unneeded
-
   def install
     bin.install "jp"
   end


### PR DESCRIPTION
Brew deprecated bottle :unneeded in June 2021
https://github.com/Homebrew/brew/pull/11239

![image](https://user-images.githubusercontent.com/5071859/138367593-4eeb7b94-1d78-464b-8d63-a1076f12a7ce.png)
